### PR TITLE
Remove memory locking

### DIFF
--- a/integration_test/docker/docker-compose.yaml
+++ b/integration_test/docker/docker-compose.yaml
@@ -77,7 +77,6 @@ services:
       - "1"
       - --devnetGuardianIndex
       - "0"
-      - --integrationTest
       - --publicRPC
       - "[::]:7070"
       - --publicWeb
@@ -110,7 +109,6 @@ services:
       - "1"
       - --devnetGuardianIndex
       - "1"
-      - --integrationTest
       - --bootstrap
       - "/dns4/guardian-0/udp/8999/quic/p2p/12D3KooWL3XJ9EMCyZvmmGXL2LMiVBtrVa2BuESsJiXkSj7333Jw"
       - --publicRPC

--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -123,7 +123,6 @@ var (
 	logLevel *string
 
 	devnetGuardianIndex *int
-	integrationTest     *bool
 
 	network  *string
 	nodeName *string
@@ -224,7 +223,6 @@ func init() {
 	logLevel = NodeCmd.Flags().String("logLevel", "info", "Logging level (debug, info, warn, error, dpanic, panic, fatal)")
 
 	devnetGuardianIndex = NodeCmd.Flags().Int("devnetGuardianIndex", 0, "Specify devnet guardian index")
-	integrationTest = NodeCmd.Flags().Bool("integrationTest", false, "Launch node for integration testing")
 
 	network = NodeCmd.Flags().String("network", "", "Network type (devnet, testnet, mainnet)")
 	nodeName = NodeCmd.Flags().String("nodeName", "", "Node name to announce in gossip heartbeats")
@@ -290,14 +288,6 @@ func runNode(cmd *cobra.Command, args []string) {
 		fmt.Print(devwarning)
 	}
 
-	if *integrationTest && !unsafeDevMode {
-		fmt.Println("Integration tests can only be run in devnet mode")
-		os.Exit(1)
-	}
-
-	if !*integrationTest {
-		common.LockMemory()
-	}
 	common.SetRestrictiveUmask()
 
 	// Refuse to run as root in production mode.


### PR DESCRIPTION
Reason for removing memory lock:

Our signing key is done through KMS, they will never end up in memory.
