### PR TITLE
Increase polling interval of ETH watcher

### DIFF
--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -61,7 +61,8 @@ var (
 	guardianKeyPath *string
 	// solanaContract  *string
 
-	ethRPC *string
+	ethRPC            *string
+	ethPollIntervalMs *uint
 
 	// bscRPC      *string
 	// bscContract *string
@@ -163,6 +164,7 @@ func init() {
 	// solanaContract = NodeCmd.Flags().String("solanaContract", "", "Address of the Solana program (required)")
 
 	ethRPC = NodeCmd.Flags().String("ethRPC", "", "Ethereum RPC URL")
+	ethPollIntervalMs = NodeCmd.Flags().Uint("ethPollIntervalMs", 1000, "The poll interval for ethereum watcher")
 
 	// bscRPC = NodeCmd.Flags().String("bscRPC", "", "Binance Smart Chain RPC URL")
 	// bscContract = NodeCmd.Flags().String("bscContract", "", "Binance Smart Chain contract address")
@@ -674,7 +676,7 @@ func runNode(cmd *cobra.Command, args []string) {
 		}
 
 		if err := supervisor.Run(ctx, "ethwatch",
-			ethereum.NewEthWatcher(*ethRPC, ethContract, "eth", common.ReadinessEthSyncing, vaa.ChainIDEthereum, lockC, setC, 1, chainObsvReqC[vaa.ChainIDEthereum], unsafeDevMode).Run); err != nil {
+			ethereum.NewEthWatcher(*ethRPC, ethContract, "eth", common.ReadinessEthSyncing, vaa.ChainIDEthereum, lockC, setC, 1, chainObsvReqC[vaa.ChainIDEthereum], unsafeDevMode, *ethPollIntervalMs).Run); err != nil {
 			return err
 		}
 

--- a/node/pkg/ethereum/watcher.go
+++ b/node/pkg/ethereum/watcher.go
@@ -127,7 +127,9 @@ func NewEthWatcher(
 	setEvents chan *common.GuardianSet,
 	minConfirmations uint64,
 	obsvReqC chan *gossipv1.ObservationRequest,
-	unsafeDevMode bool) *Watcher {
+	unsafeDevMode bool,
+	pollIntervalMs uint,
+) *Watcher {
 
 	var ethIntf common.Ethish
 	if chainID == vaa.ChainIDCelo && !unsafeDevMode {
@@ -135,7 +137,7 @@ func NewEthWatcher(
 		// However, in devnet, we currently run the standard ETH node for Celo, so we need to use the standard go-ethereum.
 		ethIntf = &celo.CeloImpl{NetworkName: networkName}
 	} else if chainID == vaa.ChainIDEthereum && !unsafeDevMode {
-		ethIntf = &PollImpl{BaseEth: EthImpl{NetworkName: networkName}, DelayInMs: 250, IsEthPoS: true}
+		ethIntf = &PollImpl{BaseEth: EthImpl{NetworkName: networkName}, DelayInMs: int(pollIntervalMs), IsEthPoS: true}
 	} else if chainID == vaa.ChainIDMoonbeam && !unsafeDevMode {
 		ethIntf = &PollImpl{BaseEth: EthImpl{NetworkName: networkName}, Finalizer: &MoonbeamFinalizer{}, DelayInMs: 250}
 	} else if chainID == vaa.ChainIDNeon {


### PR DESCRIPTION
ETH watcher polls every 250ms to see if there is a new block. This PR added a config for ETH watcher polling interval, the default value is 1000ms.