### PR TITLE
Addressing the problem of slow initial loading

### DIFF
--- a/bridge_ui/src/components/Transactions/index.tsx
+++ b/bridge_ui/src/components/Transactions/index.tsx
@@ -93,7 +93,7 @@ function useBlockNumber(fetcherGetter: (chainId: ChainId) => (BlockNumberFetcher
   const pollingInterval = chainId === CHAIN_ID_ALEPHIUM ? ALEPHIUM_POLLING_INTERVAL : 3000
   const fetcher = fetcherGetter(chainId)
   const { data: blockNumber, error } = useSWR(
-    `${chainName}-block-number`,
+    fetcher === undefined ? null : `${chainName}-block-number`,
     () => fetcher === undefined ? undefined : fetcher(),
     { refreshInterval: pollingInterval }
   )
@@ -212,7 +212,7 @@ export default function Transactions() {
 
   const blockNumberFetcherGetter = useCallback((chainId: ChainId) => {
     if (chainId === CHAIN_ID_ALEPHIUM) {
-      return () => alphBlockNumberFetcher(alphWallet)
+      return alphWallet === undefined ? undefined : () => alphBlockNumberFetcher(alphWallet)
     }
     if (bothAreEvmChain) {
       if (chainId === txSourceChain && sourceChainReady) {


### PR DESCRIPTION
In the beginning, the `alphWallet` is undefined, and the retrieval of the block height failed, so it had to wait until the next polling to fetch it again, resulting in a slow initial loading of transaction status. 

Now this problem has been resolved by using [swr conditional fetching](https://swr.vercel.app/docs/conditional-fetching). I have tested with the latest code, and now the transactions page responds much faster.