### PR TITLE
Fix getting next governance sequence

### DIFF
--- a/bridge_ui/src/utils/consts.ts
+++ b/bridge_ui/src/utils/consts.ts
@@ -66,11 +66,11 @@ const alephiumChainInfo: ChainInfo = {
 export const CHAINS: ChainInfo[] =
   CLUSTER === "mainnet"
     ? [
-        {
-          id: CHAIN_ID_BSC,
-          name: "Binance Smart Chain",
-          logo: bscIcon,
-        },
+        // {
+        //   id: CHAIN_ID_BSC,
+        //   name: "Binance Smart Chain",
+        //   logo: bscIcon,
+        // },
         {
           id: CHAIN_ID_ETH,
           name: "Ethereum",
@@ -80,11 +80,11 @@ export const CHAINS: ChainInfo[] =
       ]
     : CLUSTER === "testnet"
     ? [
-        {
-          id: CHAIN_ID_BSC,
-          name: "Binance Smart Chain",
-          logo: bscIcon,
-        },
+        // {
+        //   id: CHAIN_ID_BSC,
+        //   name: "Binance Smart Chain",
+        //   logo: bscIcon,
+        // },
         {
           id: CHAIN_ID_ETH,
           name: "Ethereum (Goerli)",

--- a/clients/js/alph.ts
+++ b/clients/js/alph.ts
@@ -1,4 +1,4 @@
-import { CONFIGS, NetworkType } from './configs'
+import { CONFIGS, Guardians, NetworkType } from './configs'
 import { impossible } from './utils'
 import { web3, binToHex, addressFromContractId, ExecuteScriptResult, SignerProvider, ExecuteScriptParams, HexString, ExecutableScript } from '@alephium/web3'
 import { PrivateKeyWallet } from '@alephium/web3-wallet'
@@ -137,15 +137,10 @@ export async function executeGovernanceAlph(
   }
 }
 
-export async function getNextGovernanceSequence(networkType: NetworkType, nodeUrl?: string): Promise<bigint> {
-  const network = CONFIGS[networkType]['alephium']
-  web3.setCurrentNodeProvider(nodeUrl ?? network.rpc)
-  const governanceAddress = addressFromContractId(network.governanceAddress)
-  const governance = Governance.at(governanceAddress)
-  const sequence0 = (await governance.fetchState()).fields.receivedSequence
-
-  const tokenBridgeAddress = addressFromContractId(network.tokenBridgeAddress)
-  const tokenBridge = TokenBridge.at(tokenBridgeAddress)
-  const sequence1 = (await tokenBridge.fetchState()).fields.receivedSequence
-  return sequence0 > sequence1 ? sequence0 : sequence1
+export async function getNextGovernanceSequence(networkType: NetworkType, explorerApiUrl: string): Promise<number> {
+  const guardianConfig = Guardians[networkType]
+  const url = `${explorerApiUrl}/api/vaas/next-governance-sequence/${guardianConfig.governanceChainId}/${guardianConfig.governanceEmitterAddress}`
+  const response = await fetch(url)
+  const json = await response.json()
+  return json['sequence'] as number
 }

--- a/clients/js/main.ts
+++ b/clients/js/main.ts
@@ -501,37 +501,29 @@ yargs(hideBin(process.argv))
     }
   )
   .command(
-    "alph",
-    "Alephium utilities",
+    "get-next-governance-sequence",
+    "Get the next governance sequence",
     (yargs) => {
       return yargs
-        .command(
-          "get-next-governance-sequence",
-          "Get the next governance sequence",
-          (yargs) => {
-            return yargs
-              .option("network", {
-                describe: "network",
-                type: "string",
-                choices: ["mainnet", "testnet", "devnet"],
-                required: true,
-              })
-              .option("node-url", {
-                describe: "Alephium full node url",
-                type: "string",
-                required: false,
-              });
-          },
-          async (argv) => {
-            const network = argv.network.toUpperCase() as NetworkType
-            const sequence = await getNextGovernanceSequence(network, argv['node-url'])
-            console.log(`The next governnace sequence is: ${sequence}`)
-          }
-        )
+        .option("network", {
+          alias: 'n',
+          describe: "network",
+          type: "string",
+          choices: ["mainnet", "testnet", "devnet"],
+          required: true,
+        })
+        .option("explorer-api-server-url", {
+          alias: 'u',
+          describe: "Explorer api server url",
+          type: "string",
+          required: true,
+        });
     },
-    (_) => {
-      yargs.showHelp();
-    }
+    async (argv) => {
+      const network = argv.network.toUpperCase() as NetworkType
+      const sequence = await getNextGovernanceSequence(network, argv['explorer-api-server-url'])
+      console.log(`The next governnace sequence is: ${sequence}`)
+    },
   )
   ////////////////////////////////////////////////////////////////////////////////
   // Submit

--- a/configs/alephium/mainnet.json
+++ b/configs/alephium/mainnet.json
@@ -5,17 +5,18 @@
   "minimalConsistencyLevel": 105,
   "messageFee": "0",
   "contracts": {
-    "governance": "",
-    "nativeGovernance": "",
-    "tokenBridge": "",
-    "nativeTokenBridge": "",
-    "bridgeRewardRouter": "",
-    "testToken": ""
+    "governance": "a5b0aafe9d183b8a5811af6f82ae9a51721e159493cde4cec8da0f6cd64b7300",
+    "nativeGovernance": "25qjdRj5hg18b5uWj1krgRAAnm6i6eqHoXmKG9GvemqrP",
+    "tokenBridge": "ef024cb46f2c7fe1940818744bb64cb577df044b59e31690404be639eafe1800",
+    "nativeTokenBridge": "2AmwaxT1jGZ28wYB28m9zzD1dCT7cgm19tubLsUT7Lkxf",
+    "bridgeRewardRouter": "a823248865e8fb2df52d6955abc5e6edf8a1e5f236f230d72423ec2eb51eaf00"
   },
-  "nodeUrl": "",
-  "explorerUrl": "",
+  "nodeUrl": "https://node-v20.mainnet.alephium.org",
+  "explorerUrl": "https://backend-v113.mainnet.alephium.org",
   "networkId": 0,
-  "coreEmitterAddress": "",
-  "tokenBridgeEmitterAddress": "",
-  "bridgeTokens": []
+  "coreEmitterAddress": "a5b0aafe9d183b8a5811af6f82ae9a51721e159493cde4cec8da0f6cd64b7300",
+  "tokenBridgeEmitterAddress": "ef024cb46f2c7fe1940818744bb64cb577df044b59e31690404be639eafe1800",
+  "bridgeTokens": [
+    "0000000000000000000000000000000000000000000000000000000000000000"
+  ]
 }

--- a/configs/ethereum/mainnet.json
+++ b/configs/ethereum/mainnet.json
@@ -2,14 +2,14 @@
   "chainId": 2,
   "wrappedNative": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
   "contracts": {
-    "governance": "",
-    "tokenBridge": "",
+    "governance": "0xD583089D29311C6E8d075c699404aB0eC539b0B7",
+    "tokenBridge": "0x3a93b292Ac5ad34dDc4260fF03BFD28e134A082d",
     "wrappedNative": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
   },
-  "nodeUrl": "",
-  "coreEmitterAddress": "",
-  "tokenBridgeEmitterAddress": "",
+  "nodeUrl": "https://mainnet.infura.io/v3/",
+  "coreEmitterAddress": "000000000000000000000000D583089D29311C6E8d075c699404aB0eC539b0B7",
+  "tokenBridgeEmitterAddress": "0000000000000000000000003a93b292Ac5ad34dDc4260fF03BFD28e134A082d",
   "bridgeTokens": [
-    "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+    "0xb4fbf271143f4fbf7b91a5ded31805e42b2208d6"
   ]
 }

--- a/configs/guardian/mainnet.json
+++ b/configs/guardian/mainnet.json
@@ -1,6 +1,13 @@
 {
   "governanceChainId": 0,
   "governanceEmitterAddress": "0000000000000000000000000000000000000000000000000000000000000004",
-  "initSigners": [],
-  "guardianUrls": []
+  "initSigners": [
+    "0x2F10c48859bf00F743971aCb287b8876bC9ef7F3",
+    "0x8A3Bc2996485A9e49B104601F40d7b75b79ce3a9",
+    "0xEa7d9D838ea90D2316Ab0c80c8D92719AD5885e8",
+    "0x99068B602684ac2227F21463bf90c29bcBA651Ef"
+  ],
+  "guardianUrls": [
+    "https://guardian-0.mainnet.bridge.alephium.org"
+  ]
 }

--- a/explorer-api-server/handlers/vaa/controller.go
+++ b/explorer-api-server/handlers/vaa/controller.go
@@ -125,6 +125,24 @@ func (c *Controller) FindById(ctx *fiber.Ctx) error {
 	return ctx.JSON(vaa)
 }
 
+func (c *Controller) GetNextGovernanceSequence(ctx *fiber.Ctx) error {
+	emitterChain, addr, err := middleware.ExtractVAAChainIDEmitter(ctx, c.logger)
+	if err != nil {
+		return err
+	}
+
+	sequence, err := c.srv.GetNextGovernanceSequence(ctx.Context(), emitterChain, addr)
+	if err != nil {
+		return err
+	}
+	response := struct {
+		Sequence uint64 `json:"sequence"`
+	}{
+		Sequence: *sequence,
+	}
+	return ctx.JSON(response)
+}
+
 // FindByTxId handler for the endpoint /vaas/transactions/:txId
 func (c *Controller) FindByTxId(ctx *fiber.Ctx) error {
 	txId, err := middleware.ExtractTransactionId(ctx, c.logger)

--- a/explorer-api-server/main.go
+++ b/explorer-api-server/main.go
@@ -165,6 +165,7 @@ func run(cmd *cobra.Command, args []string) {
 	vaas.Get("/vaa-counts", vaaCtrl.GetVaaCount)
 	vaas.Get("/recent", vaaCtrl.FindRecent)
 	vaas.Get("/transactions/:txId", vaaCtrl.FindByTxId)
+	vaas.Get("/next-governance-sequence/:emitterChain/:emitterAddress", vaaCtrl.GetNextGovernanceSequence)
 	vaas.Get("/:emitterChain", vaaCtrl.FindByChain)
 	vaas.Get("/:emitterChain/:emitterAddress", vaaCtrl.FindByEmitter)
 	vaas.Get("/:emitterChain/:emitterAddress/:targetChain", vaaCtrl.FindByEmitterAndTargetChain)

--- a/explorer-backend/go.mod
+++ b/explorer-backend/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 // indirect
 	github.com/XiaoMi/pegasus-go-client v0.0.0-20210427083443-f3b6b08bc4c2 // indirect
 	github.com/alephium/go-sdk v0.0.0-20230918114914-5feda0147395
-	github.com/alephium/wormhole-fork/node v0.0.0-20230918120223-dce63cd68586
+	github.com/alephium/wormhole-fork/node v0.0.0-20231019002157-bf40b14f9721
 	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/explorer-backend/go.sum
+++ b/explorer-backend/go.sum
@@ -113,10 +113,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alephium/go-sdk v0.0.0-20230918114914-5feda0147395 h1:O7rTSCEBrwFMnpBSwxQnbkqWrmC0o+hSTPWZUPVEYvY=
 github.com/alephium/go-sdk v0.0.0-20230918114914-5feda0147395/go.mod h1:sBGuQu5WyKJQBkYp/9VVCfm2h8fcjd16dsZma0+hcSE=
-github.com/alephium/wormhole-fork/node v0.0.0-20230527022850-42486ede48db h1:3imx4BJaUKD7E/ukknYG0gjnV+9x+xq4oei50OqLEGc=
-github.com/alephium/wormhole-fork/node v0.0.0-20230527022850-42486ede48db/go.mod h1:DhROmhB2p43HhvukX5IaetFS4u6SFHthQczNdPodSWk=
-github.com/alephium/wormhole-fork/node v0.0.0-20230918120223-dce63cd68586 h1:R+YJbkyLSZlh9R71VSlE4u59tW4jb2D2sqNW1WUdFN0=
-github.com/alephium/wormhole-fork/node v0.0.0-20230918120223-dce63cd68586/go.mod h1:tJHrk5OPB+rlthmfIhCoScfGV07NCew+mPss9A5CKB0=
+github.com/alephium/wormhole-fork/node v0.0.0-20231019002157-bf40b14f9721 h1:eNNTq7UmccV9e2SsxEtOs5xm4ilvAOVOSliHg13K2a4=
+github.com/alephium/wormhole-fork/node v0.0.0-20231019002157-bf40b14f9721/go.mod h1:tJHrk5OPB+rlthmfIhCoScfGV07NCew+mPss9A5CKB0=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/allegro/bigcache v1.2.1/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/allegro/bigcache/v3 v3.1.0 h1:H2Vp8VOvxcrB91o86fUSVJFqeuz8kpyyB02eH3bSzwk=

--- a/explorer-backend/main.go
+++ b/explorer-backend/main.go
@@ -368,26 +368,28 @@ func run(cmd *cobra.Command, args []string) {
 			return err
 		}
 
-		bscEventIndex, err := watcher.GetLatestEventIndexBsc(ctx)
-		if err != nil {
-			logger.Error("failed to get latest event index", zap.Uint16("chainId", uint16(vaa.ChainIDBSC)), zap.Error(err))
-			return err
-		}
-		bscWatcher, err := transactions.NewEVMWatcher(
-			logger,
-			ctx,
-			*bscRpcUrl,
-			vaa.ChainIDBSC,
-			bridgeConfig.Bsc,
-			*bscEventIndex,
-			blockTxsC,
-		)
-		if err != nil {
-			logger.Error("failed to create bsc watcher", zap.Error(err))
-			return err
-		}
-		if err := supervisor.Run(ctx, "bsc-watcher", bscWatcher.Run()); err != nil {
-			return err
+		if *bscRpcUrl != "" {
+			bscEventIndex, err := watcher.GetLatestEventIndexBsc(ctx)
+			if err != nil {
+				logger.Error("failed to get latest event index", zap.Uint16("chainId", uint16(vaa.ChainIDBSC)), zap.Error(err))
+				return err
+			}
+			bscWatcher, err := transactions.NewEVMWatcher(
+				logger,
+				ctx,
+				*bscRpcUrl,
+				vaa.ChainIDBSC,
+				bridgeConfig.Bsc,
+				*bscEventIndex,
+				blockTxsC,
+			)
+			if err != nil {
+				logger.Error("failed to create bsc watcher", zap.Error(err))
+				return err
+			}
+			if err := supervisor.Run(ctx, "bsc-watcher", bscWatcher.Run()); err != nil {
+				return err
+			}
 		}
 
 		if err := supervisor.Run(ctx, "watcher", watcher.Run()); err != nil {

--- a/explorer-backend/main.go
+++ b/explorer-backend/main.go
@@ -368,7 +368,7 @@ func run(cmd *cobra.Command, args []string) {
 			return err
 		}
 
-		if *bscRpcUrl != "" {
+		if *bscRpcUrl != "" && *network == "devnet" {
 			bscEventIndex, err := watcher.GetLatestEventIndexBsc(ctx)
 			if err != nil {
 				logger.Error("failed to get latest event index", zap.Uint16("chainId", uint16(vaa.ChainIDBSC)), zap.Error(err))

--- a/explorer-backend/storage/fetcher.go
+++ b/explorer-backend/storage/fetcher.go
@@ -12,14 +12,18 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
+type BridgeChain struct {
+	chainId vaa.ChainID
+	*common.ChainConfig
+}
+
 func loadEmitterIds(config *common.BridgeConfig) ([]*emitterId, error) {
-	chains := []struct {
-		chainId vaa.ChainID
-		*common.ChainConfig
-	}{
+	chains := []BridgeChain{
 		{vaa.ChainIDAlephium, config.Alephium},
 		{vaa.ChainIDEthereum, config.Ethereum},
-		{vaa.ChainIDBSC, config.Bsc},
+	}
+	if config.Bsc != nil {
+		chains = append(chains, BridgeChain{vaa.ChainIDBSC, config.Bsc})
 	}
 	emitterIds := make([]*emitterId, 0)
 	for i := 0; i < len(chains); i++ {

--- a/explorer-backend/transactions/watcher.go
+++ b/explorer-backend/transactions/watcher.go
@@ -138,7 +138,7 @@ func getEthereumDefaultEventIndex(networkId common.NetworkId) uint32 {
 	case common.DEVNET:
 		return 0
 	case common.TESTNET:
-		return 8934485 // the block height of the contract deployment tx
+		return 9876190 // the block height of the contract deployment tx
 	case common.MAINNET:
 		panic("eth event index not specified") // TODO: the block height of the contract deployment tx
 	default:

--- a/explorer/package-lock.json
+++ b/explorer/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "wormhole",
+  "name": "Alephium Bridge Explorer",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "wormhole",
+      "name": "Alephium Bridge Explorer",
       "version": "1.0.0",
       "dependencies": {
         "@alephium/web3": "^0.18.2",

--- a/explorer/src/components/ExplorerSearch/ExplorerSummary.tsx
+++ b/explorer/src/components/ExplorerSearch/ExplorerSummary.tsx
@@ -17,7 +17,7 @@ import {
 import { OutboundLink } from "gatsby-plugin-google-gtag";
 import { ChainID, chainIDs } from "../../utils/consts";
 import { hexToNativeString, uint8ArrayToHex } from "@alephium/wormhole-sdk";
-import { explorer } from "../../utils/urls";
+import { home } from "../../utils/urls";
 
 interface SummaryProps {
   emitterChain?: number;
@@ -78,7 +78,7 @@ const ExplorerSummary = (props: SummaryProps) => {
         <Typography variant="h4">Message Summary</Typography>
           <div>
             <Button onClick={props.refetch}>Refresh</Button>
-            <Button component={RouterLink} to={explorer} sx={{ ml: 1 }}>
+            <Button component={RouterLink} to={home} sx={{ ml: 1 }}>
               Clear
             </Button>
           </div>

--- a/explorer/src/components/ExplorerStats/ExplorerStats.tsx
+++ b/explorer/src/components/ExplorerStats/ExplorerStats.tsx
@@ -11,7 +11,6 @@ import ethereumIcon from "../../images/eth.svg";
 import binanceChainIcon from "../../images/bsc.svg";
 import alephiumIcon from "../../images/alephium.svg"
 import GridWithCards from "../GridWithCards";
-import { explorer } from "../../utils/urls";
 
 export interface Totals {
   TotalCount: { [groupByKey: string]: number };
@@ -394,7 +393,7 @@ const ExplorerStats: React.FC<StatsProps> = ({
               {
                 header: ChainID[2],
                 src: ethereumIcon,
-                to: `${explorer}?emitterChain=2`,
+                to: `?emitterChain=2`,
                 description: (
                   <ChainOverviewCard
                     totals={totals}
@@ -406,23 +405,9 @@ const ExplorerStats: React.FC<StatsProps> = ({
                 imgStyle: { height: 110 },
               },
               {
-                header: ChainID[4],
-                src: binanceChainIcon,
-                to: `${explorer}?emitterChain=4`,
-                description: (
-                  <ChainOverviewCard
-                    totals={totals}
-                    notionalTransferredTo={notionalTransferredTo}
-                    notionalTransferred={notionalTransferred}
-                    dataKey="4"
-                  />
-                ),
-                imgStyle: { height: 110 },
-              },
-              {
                 header: ChainID[255],
                 src: alephiumIcon,
-                to: `${explorer}?emitterChain=255`,
+                to: `?emitterChain=255`,
                 description: (
                   <ChainOverviewCard
                     totals={totals}

--- a/explorer/src/components/ExplorerStats/RecentMessages.tsx
+++ b/explorer/src/components/ExplorerStats/RecentMessages.tsx
@@ -17,7 +17,6 @@ import {
 import { contractNameFormatter } from "../../utils/explorer";
 import { chainIDs } from "../../utils/consts";
 import { formatQuorumDate } from "../../utils/time";
-import { explorer } from "../../utils/urls";
 import ChainIcon from "../ChainIcon";
 import { DecodePayload } from "../DecodePayload";
 
@@ -166,7 +165,7 @@ const RecentMessages = (props: RecentMessagesProps) => {
                 <TableCell>
                   <Link
                     component={RouterLink}
-                    to={`${explorer}?emitterChain=${toChainId(item.EmitterChain)}&emitterAddress=${item.EmitterAddress}&targetChain=${toChainId(item.TargetChain)}&sequence=${item.Sequence}`}
+                    to={`?emitterChain=${toChainId(item.EmitterChain)}&emitterAddress=${item.EmitterAddress}&targetChain=${toChainId(item.TargetChain)}&sequence=${item.Sequence}`}
                     color="inherit"
                   >
                     View

--- a/explorer/src/utils/consts.ts
+++ b/explorer/src/utils/consts.ts
@@ -16,7 +16,7 @@ import { default as bscMainnetConfig } from '../../../configs/bsc/mainnet.json'
 
 export const chainEnums = [
   "Ethereum",
-  "BSC",
+  // "BSC",
   "Alephium"
 ];
 
@@ -26,19 +26,19 @@ export interface ChainIDs {
 
 export const chainIDs: ChainIDs = {
   ethereum: 2,
-  bsc: 4,
+  // bsc: 4,
   alephium: 255,
 };
 
 export const chainIDStrings: { [chainIDString: string]: string } = {
   "2": "ethereum",
-  "4": "bsc",
+  // "4": "bsc",
   "255": "alephium",
 };
 
 export enum ChainID {
   Ethereum = 2,
-  BSC = 4,
+  // BSC = 4,
   Alephium = 255,
 }
 export type ChainName = keyof ChainIDs;

--- a/integration_test/src/governance/governance_utils.ts
+++ b/integration_test/src/governance/governance_utils.ts
@@ -47,9 +47,9 @@ export async function runCmdInContainer(container: Container, cmd: string[], wor
 }
 
 export function getNextGovernanceSequence() {
-  const command = `npm --prefix ../clients/js start -- alph get-next-governance-sequence --network devnet`
+  const command = `npm --prefix ../clients/js start -- get-next-governance-sequence -n devnet -u http://127.0.0.1:8100`
   const output = execSync(command)
-  const numberStr = output.toString('utf8').split(':')[1]
+  const numberStr = output.toString('utf8').slice(output.lastIndexOf(":") + 2)
   return parseInt(numberStr)
 }
 

--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -373,10 +373,8 @@ func runNode(cmd *cobra.Command, args []string) {
 	}
 	alphConfig := bridgeConfig.Alephium
 	ethConfig := bridgeConfig.Ethereum
-	bscConfig := bridgeConfig.Bsc
 
 	ethContract := eth_common.HexToAddress(ethConfig.Contracts.Governance)
-	bscContract := eth_common.HexToAddress(bscConfig.Contracts.Governance)
 
 	governanceChainId := vaa.ChainID(bridgeConfig.Guardian.GovernanceChainId)
 	governanceEmitterAddress, err := vaa.StringToAddress(bridgeConfig.Guardian.GovernanceEmitterAddress)
@@ -678,7 +676,9 @@ func runNode(cmd *cobra.Command, args []string) {
 			return err
 		}
 
-		if *bscRPC != "" {
+		if *bscRPC != "" && *network == "devnet" {
+			bscConfig := bridgeConfig.Bsc
+			bscContract := eth_common.HexToAddress(bscConfig.Contracts.Governance)
 			if err := supervisor.Run(ctx, "bscwatch",
 				ethereum.NewEthWatcher(*bscRPC, bscContract, "bsc", common.ReadinessBSCSyncing, vaa.ChainIDBSC, lockC, setC, chainObsvReqC[vaa.ChainIDBSC], unsafeDevMode, bscPollIntervalMs, true).Run); err != nil {
 				return err

--- a/node/pkg/common/configs.go
+++ b/node/pkg/common/configs.go
@@ -170,9 +170,12 @@ func ReadConfigsByNetwork(network string) (*BridgeConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	bscConfig, err := ReadBscConfig(network)
-	if err != nil {
-		return nil, err
+	var bscConfig *ChainConfig
+	if networkId == DEVNET {
+		bscConfig, err = ReadBscConfig(network)
+		if err != nil {
+			return nil, err
+		}
 	}
 	guardianConfig, err := ReadGuardianConfig(network)
 	if err != nil {


### PR DESCRIPTION
We need to get the current governance sequence from all chains and then use the `max(governanceSeqsFromAllChains) + 1` as the next governance sequence. But we cannot determine how many governance VAA have already been executed from the ETH contract(as ETH does not store sequence info but uses a map to record all executed VAA, and in Solidity, we cannot get the size of a map). So I modified it here to get the next governance sequence from the explorer-backend.