### PR TITLE
Fallback to the public node service if cannot fetch the latest block …

### DIFF
--- a/bridge_ui/src/hooks/useHandleAttest.tsx
+++ b/bridge_ui/src/hooks/useHandleAttest.tsx
@@ -175,7 +175,7 @@ async function evm(
       getTokenBridgeAddressForChain(chainId)
     );
     if (signer.provider) {
-      await waitEVMTxConfirmed(signer.provider, receipt, chainId)
+      await waitEVMTxConfirmed(signer.provider, receipt.blockNumber, chainId)
     }
     enqueueSnackbar(null, {
       content: <Alert severity="info">Fetching VAA</Alert>,

--- a/bridge_ui/src/hooks/useHandleTransfer.tsx
+++ b/bridge_ui/src/hooks/useHandleTransfer.tsx
@@ -224,7 +224,7 @@ async function evm(
       getTokenBridgeAddressForChain(chainId)
     );
     if (signer.provider) {
-      await waitEVMTxConfirmed(signer.provider, receipt, chainId)
+      await waitEVMTxConfirmed(signer.provider, receipt.blockNumber, chainId)
     }
     enqueueSnackbar(null, {
       content: <Alert severity="info">Fetching VAA</Alert>,

--- a/bridge_ui/src/utils/consts.ts
+++ b/bridge_ui/src/utils/consts.ts
@@ -277,7 +277,7 @@ export const SOLANA_HOST = process.env.REACT_APP_SOLANA_API_URL
 
 export const ETH_RPC_HOST =
   CLUSTER === 'mainnet'
-    ? ''
+    ? 'https://ethereum.publicnode.com'
     : CLUSTER === 'testnet'
     ? 'https://ethereum-goerli.publicnode.com'
     : 'http://localhost:8545'


### PR DESCRIPTION
When fetching the block number through metamask, sometimes metamask may use a cache, which causes the use of a stale block number. And I haven't found any docs about this.

In this PR, if the block number still does not change after 8 minutes(slightly longer than one epoch), it will try to get the block number from the public node RPC service.