### PR TITLE
Fix wait tx confirmations

### DIFF
--- a/bridge_ui/src/components/TokenSelectors/TokenPicker.tsx
+++ b/bridge_ui/src/components/TokenSelectors/TokenPicker.tsx
@@ -8,7 +8,6 @@ import {
   DialogTitle,
   Divider,
   IconButton,
-  Link,
   List,
   ListItem,
   makeStyles,
@@ -27,7 +26,6 @@ import { NFTParsedTokenAccount } from "../../store/nftSlice";
 import { selectTransferTargetChain } from "../../store/selectors";
 import { balancePretty } from "../../utils/balancePretty";
 import {
-  AVAILABLE_MARKETS_URL,
   CHAINS_BY_ID,
   getIsTokenTransferDisabled,
 } from "../../utils/consts";

--- a/bridge_ui/src/utils/alephium.ts
+++ b/bridge_ui/src/utils/alephium.ts
@@ -65,9 +65,13 @@ export class AlphTxInfo {
 }
 
 export async function waitALPHTxConfirmed(provider: NodeProvider, txId: string, confirmations: number): Promise<node.Confirmed> {
-  const txStatus = await provider.transactions.getTransactionsStatus({txId: txId})
-  if (isAlphTxConfirmed(txStatus) && txStatus.chainConfirmations >= confirmations) {
-    return txStatus as node.Confirmed
+  try {
+    const txStatus = await provider.transactions.getTransactionsStatus({txId: txId})
+    if (isAlphTxConfirmed(txStatus) && txStatus.chainConfirmations >= confirmations) {
+      return txStatus as node.Confirmed
+    }
+  } catch (error) {
+    console.error(`failed to get tx status, tx id: ${txId}`)
   }
   await sleep(ALEPHIUM_POLLING_INTERVAL)
   return waitALPHTxConfirmed(provider, txId, confirmations)


### PR DESCRIPTION
Sometimes it throws an exception when fetching the tx status. We need to handle this exception within the function `waitALPHTxConfirmed`, otherwise it will result in not being able to retrieve the signed vaa here: https://github.com/alephium/wormhole-fork/blob/95b3d9b062635d8b31d45a41b036d85c8c322af2/bridge_ui/src/hooks/useHandleTransfer.tsx#L394