### PR TITLE
Fix alephium event handler

### DIFF
--- a/node/pkg/alephium/reobserve.go
+++ b/node/pkg/alephium/reobserve.go
@@ -146,8 +146,9 @@ func (w *Watcher) getGovernanceEventsByTxId(
 			}
 		}
 
+		contractEvent := event
 		reobservedEvents = append(reobservedEvents, &reobservedEvent{
-			&event,
+			&contractEvent,
 			msg.consistencyLevel,
 			header,
 			txId,


### PR DESCRIPTION
 Due to [this issue](https://github.com/dominikh/go-tools/issues/163), some events are lost in the events handler. This pull request actually modifies only two lines of code, from:

```
unconfirmed, err := w.toUnconfirmedEvent(&event)
```

to:

```
contractEvent := event
unconfirmed, err := w.toUnconfirmedEvent(&contractEvent)
```

We need to update the guardian after this PR is merged.