### PR TITLE
Fix the eth token list url

### DIFF
--- a/bridge_ui/src/utils/ethereum.ts
+++ b/bridge_ui/src/utils/ethereum.ts
@@ -26,7 +26,7 @@ let _whitelist: TokenInfo[] | undefined = undefined
 
 async function loadETHTokenWhitelist(): Promise<TokenInfo[]> {
   if (_whitelist !== undefined) return _whitelist
-  const { data: { tokens } } = await axios.get('https://ipfs.io/ipns/tokens.1inch.eth/')
+  const { data: { tokens } } = await axios.get('https://tokens-1inch-eth.ipns.dweb.link/')
   _whitelist = tokens
   return tokens
 }


### PR DESCRIPTION
The ETH token list URL we use has changed several times recently, and every time the URL changes, using the old URL will cause CORS errors in the browser, and we have to manually update the code to the new URL and redeploy the bridge ui. Do you think it is necessary for us to maintain an ETH token list on Github?