### PR TITLE
Fix github workflow

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -7,7 +7,7 @@ on:
       - master
 jobs:
   alephium:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js
@@ -19,7 +19,7 @@ jobs:
         run: npm audit --production
 
   sdk:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -27,7 +27,7 @@ jobs:
           echo ::set-output name=DIST_TAG::$dist_tag
         shell: bash
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: get_dist_tag
     permissions:
       id-token: write


### PR DESCRIPTION
Github runner does not support ubuntu-20.04 anymore:
```
This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101
```